### PR TITLE
싱글톤 스코프와 리퀘스트 스코프의 충돌을 재현한다.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,7 @@ repositories {
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
+    implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/lectureBasic/core/common/MyLogger.kt
+++ b/src/main/kotlin/lectureBasic/core/common/MyLogger.kt
@@ -1,0 +1,32 @@
+package lectureBasic.core.common
+
+import org.springframework.context.annotation.Scope
+import org.springframework.stereotype.Component
+import java.util.UUID
+import javax.annotation.PreDestroy
+
+@Component
+@Scope(value = "request")
+class MyLogger {
+
+    private lateinit var uuid: String
+    private lateinit var requestUrl: String
+
+    init {
+        uuid = UUID.randomUUID().toString()
+        println("[$uuid] request scope bean create $this")
+    }
+
+    @PreDestroy
+    fun close() {
+        println("[$uuid] request scope bean close $this")
+    }
+
+    fun setRequestUrl(requestUrl: String) {
+        this.requestUrl = requestUrl
+    }
+
+    fun log(message: String) {
+        println("[$uuid][$requestUrl] $message")
+    }
+}

--- a/src/main/kotlin/lectureBasic/core/logdemo/LogDemoService.kt
+++ b/src/main/kotlin/lectureBasic/core/logdemo/LogDemoService.kt
@@ -1,0 +1,14 @@
+package lectureBasic.core.logdemo
+
+import lectureBasic.core.common.MyLogger
+import org.springframework.stereotype.Service
+
+@Service
+class LogDemoService(
+    private val myLogger: MyLogger
+) {
+
+    fun logic(id: String) {
+        myLogger.log("service Id = $id")
+    }
+}

--- a/src/main/kotlin/lectureBasic/core/web/LogDemoController.kt
+++ b/src/main/kotlin/lectureBasic/core/web/LogDemoController.kt
@@ -1,0 +1,27 @@
+package lectureBasic.core.web
+
+import lectureBasic.core.common.MyLogger
+import lectureBasic.core.logdemo.LogDemoService
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import javax.servlet.http.HttpServletRequest
+
+@Controller
+class LogDemoController(
+    private val logDemoService: LogDemoService,
+    private val myLogger: MyLogger
+) {
+
+    @RequestMapping("log-demo")
+    @ResponseBody
+    fun logDemo(request: HttpServletRequest): String {
+        val requestUrl = request.requestURL.toString()
+        myLogger.setRequestUrl(requestUrl)
+
+        myLogger.log("controller test")
+        logDemoService.logic("testId")
+
+        return "OK"
+    }
+}


### PR DESCRIPTION
Caused by: org.springframework.beans.factory.support.ScopeNotActiveException: Error creating bean with name 'myLogger': Scope 'request' is not active for the current thread; consider defining a scoped proxy for this bean if you intend to refer to it from a singleton; nested exception is java.lang.IllegalStateException: No thread-bound request found: Are you referring to request attributes outside of an actual web request, or processing a request outside of the originally receiving thread? If you are actually operating within a web request and still receive this message, your code is probably running outside of DispatcherServlet: In this case, use RequestContextListener or RequestContextFilter to expose the current request.
