### PR TITLE
provider를 사용하여 싱글톤 스코프와 리퀘스트 스코프를 같이 사용했을 때에 문제를 해결하라

### DIFF
--- a/src/main/kotlin/lectureBasic/core/logdemo/LogDemoService.kt
+++ b/src/main/kotlin/lectureBasic/core/logdemo/LogDemoService.kt
@@ -1,14 +1,15 @@
 package lectureBasic.core.logdemo
 
 import lectureBasic.core.common.MyLogger
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.stereotype.Service
 
 @Service
 class LogDemoService(
-    private val myLogger: MyLogger
+    val myLoggerProvider: ObjectProvider<MyLogger>
 ) {
-
     fun logic(id: String) {
+        val myLogger = myLoggerProvider.getObject()
         myLogger.log("service Id = $id")
     }
 }

--- a/src/main/kotlin/lectureBasic/core/web/LogDemoController.kt
+++ b/src/main/kotlin/lectureBasic/core/web/LogDemoController.kt
@@ -2,6 +2,7 @@ package lectureBasic.core.web
 
 import lectureBasic.core.common.MyLogger
 import lectureBasic.core.logdemo.LogDemoService
+import org.springframework.beans.factory.ObjectProvider
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
@@ -10,13 +11,14 @@ import javax.servlet.http.HttpServletRequest
 @Controller
 class LogDemoController(
     private val logDemoService: LogDemoService,
-    private val myLogger: MyLogger
+    private val myLoggerProvider: ObjectProvider<MyLogger>
 ) {
-
     @RequestMapping("log-demo")
     @ResponseBody
     fun logDemo(request: HttpServletRequest): String {
         val requestUrl = request.requestURL.toString()
+        val myLogger = myLoggerProvider.getObject()
+
         myLogger.setRequestUrl(requestUrl)
 
         myLogger.log("controller test")


### PR DESCRIPTION
- ObjectProvider를 사용하여 ObjectProvider.geObject()를 호출하는 시점까지 request scope 빈의 생성을 지연할 수 있다.
- ObjectProvider.getObject() 를 호출하시는 시점에는 HTTP 요청이 진행중이므로 request scope 빈의 생성이 정상 처리된다.